### PR TITLE
added badges to end of project-lifecycle.md

### DIFF
--- a/Project-Lifecycle.md
+++ b/Project-Lifecycle.md
@@ -127,3 +127,10 @@ admission in groups as mentors become available.
 You can apply at any time and the TSC and available mentors will help
 improve your application while awaiting the next available approval
 phase.
+
+Once admitted, please update the relevant readme files for the project to include the appropriate Planetary Software Organization badge.
+
+| Type       | Badge | Raw Markdown |
+|------------|-------------------|------------------------|
+| Affiliate  | [![Affiliate](https://img.shields.io/badge/Planetary_Software-Affiliate-645394.svg)]() | ```[![Affiliate](https://img.shields.io/badge/Planetary_Software-Affiliate-645394.svg)](https://affiliate-url)``` |
+| Project    | [![Project](https://img.shields.io/badge/Planetary_Software-Project-645394.svg)]() | ```[![Project](https://img.shields.io/badge/Planetary_Software-Project-645394.svg)](https://project-url)``` |

--- a/Project-Lifecycle.md
+++ b/Project-Lifecycle.md
@@ -132,5 +132,5 @@ Once admitted, please update the relevant readme files for the project to includ
 
 | Type       | Badge | Raw Markdown |
 |------------|-------------------|------------------------|
-| Affiliate  | [![Affiliate](https://img.shields.io/badge/Planetary_Software-Affiliate-645394.svg)]() | ```[![Affiliate](https://img.shields.io/badge/Planetary_Software-Affiliate-645394.svg)](https://affiliate-url)``` |
-| Project    | [![Project](https://img.shields.io/badge/Planetary_Software-Project-645394.svg)]() | ```[![Project](https://img.shields.io/badge/Planetary_Software-Project-645394.svg)](https://project-url)``` |
+| Affiliate  | [![Affiliate](https://img.shields.io/badge/Planetary_Software-Affiliate-645394.svg)](https://github.com/planetarysoftware/TSC) | ```[![Affiliate](https://img.shields.io/badge/Planetary_Software-Affiliate-645394.svg)](https://github.com/planetarysoftware/TSC)``` |
+| Project    | [![Project](https://img.shields.io/badge/Planetary_Software-Project-645394.svg)](https://github.com/planetarysoftware/TSC) | ```[![Project](https://img.shields.io/badge/Planetary_Software-Project-645394.svg)](https://github.com/planetarysoftware/TSC)``` |


### PR DESCRIPTION
added the badges as a table to the end of project-lifecycle.md, might not be the right spot in that document. If other badges are needed we can add them to the table which shows the badge and the example raw markdown (can also include the equivalent RST).