### PR TITLE
Update 2019-09-03.md

### DIFF
--- a/meetings/2019-09-03.md
+++ b/meetings/2019-09-03.md
@@ -3,7 +3,7 @@
 ### Attending
 - @victoronline
 - @michaelaye
-- @rbery
+- @rbeyer
 - @sgstapleton
 - @jessemapel
 
@@ -73,7 +73,6 @@
   - Can write the TC to allow people to retain things like commit rights if they want to
   - More coming next month
 - Next meeting October 8th 12pm MST
-  - Watch out for daylight savings time!
 
 ## Discussions expected at next meeting
 - How can we improve the application process


### PR DESCRIPTION
Typo fixture and removal of DST warning, as it is a month premature.