### PR TITLE
Removed Summer from members list

### DIFF
--- a/Members.md
+++ b/Members.md
@@ -5,5 +5,4 @@
 - [Jay Laura](https://github.com/jlaura)
 - [Jesse Mapel](https://github.com/jessemapel)
 - [Victor Silva](https://github.com/victoronline)
-- [Summer Stapleton](https://github.com/SgStapleton)
 - [Andrew Annex](https://github.com/AndrewAnnex)


### PR DESCRIPTION
Summer has moved onto other things and isn't participating in the TSC anymore. This was discussed in the September meeting.