### PR TITLE
Moved agenda forward to January since we failed to attend December.

### DIFF
--- a/Meetings/2020-12-01.md
+++ b/Meetings/2020-12-01.md
@@ -1,24 +1,9 @@
 # TSC Meeting 2020 December 1st @11AM MST.
 - Zoom Link: https://cuboulder.zoom.us/j/346594091
 
-### Attending
+# Cancelled
 
--
+The time change did not propagate to the Google Calendar, and may
+not have propagated to individual calendars, thus we had an attendance fail.
 
-## Agenda / Notes
-- Action Items from last time:
-	- Jesse: Add text about proprietary dependencies
-	- Jay & Victor: PlanetaryPy Review
-
-- Report on Active Applications:
-	- ISIS (@victoronline mentor)
-	- PlanetaryPy (@jessemapel mentor
-
-- What's next for the TSC?
-
-
-## Discussions expected at next meeting, 2021 Jan 5th @ 11PM MST?
--
-
-## Action Items
--
+Agenda moved forward to January meeting.

--- a/Meetings/2021-01-05.md
+++ b/Meetings/2021-01-05.md
@@ -1,0 +1,24 @@
+# TSC Meeting 2021 January 5th @11AM MST.
+- Note time change to avoid OPLunch.
+- Zoom Link: https://cuboulder.zoom.us/j/346594091
+
+### Attending
+- ?
+
+## Agenda / Notes
+- Action Items from last time:
+	- Jesse: Add text about proprietary dependencies
+	- Jay & Victor: PlanetaryPy Review
+
+- Report on Active Applications:
+	- ISIS (@victoronline mentor)
+	- PlanetaryPy (@jessemapel mentor
+
+- What's next for the TSC?
+
+
+## Discussions expected at next meeting, 2021 Feb 2nd @ 11AM MST
+-
+
+## Action Items
+-


### PR DESCRIPTION
Time is at 11 AM, Google Calendar also now adjusted!  Please adjust your own calendars, if needed.