### PR TITLE
Converted June meeting agenda to an August meeting agenda.

### DIFF
--- a/Meetings/2024-08-27.md
+++ b/Meetings/2024-08-27.md
@@ -1,4 +1,4 @@
-# TSC Meeting 2024 July 30th @12:00 PM PDT / 12:00 PM MST / 19:00 UTC / 21:00 CEST
+# TSC Meeting 2024 August 27th @12:00 PM PDT / 12:00 PM MST / 19:00 UTC / 21:00 CEST
 - Zoom Link: https://cuboulder.zoom.us/j/346594091
 
 ### Attending
@@ -14,12 +14,12 @@ See last month's meeting notes for detail.
 
 - Brainstorm additional topics to cover at meetings.
 
-- Decide which topics to set for the August and September meetings.
+- Decide which topics to set for the September and October meetings.
 
 - Decide on "advertising" text that we would use on OpenPlanetary to get folks to attend.
 
 
-## Discussions expected at next meeting, August 27 at noon PDT.
+## Discussions expected at next meeting, September 24 at noon PDT.
 - ?
 
 ## Action Items


### PR DESCRIPTION
We did not have an end-of-June meeting, so I just converted that draft agenda to a draft agenda for August.